### PR TITLE
treat left stick as a digital input in menus

### DIFF
--- a/Assets/Scripts/Input/PlayerInputActions.cs
+++ b/Assets/Scripts/Input/PlayerInputActions.cs
@@ -279,7 +279,7 @@ namespace pf
                     ""id"": ""2d8bf38c-7242-4aab-b94b-f4bceee6bc92"",
                     ""expectedControlType"": ""Vector2"",
                     ""processors"": """",
-                    ""interactions"": """",
+                    ""interactions"": ""Press"",
                     ""initialStateCheck"": false
                 },
                 {
@@ -512,15 +512,59 @@ namespace pf
                     ""isPartOfComposite"": true
                 },
                 {
-                    ""name"": """",
-                    ""id"": ""e0c77a15-04ca-4550-bb1e-b22e60155046"",
-                    ""path"": ""<Gamepad>/leftStick"",
+                    ""name"": ""Left Stick [Gamepad]"",
+                    ""id"": ""83d380c9-a0bd-4a30-ab94-7b9706b9a7ba"",
+                    ""path"": ""2DVector"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Navigate"",
+                    ""isComposite"": true,
+                    ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": ""up"",
+                    ""id"": ""10b54bb8-b3e0-4e8e-a0e2-84e8424c9beb"",
+                    ""path"": ""<Gamepad>/leftStick/up"",
                     ""interactions"": """",
                     ""processors"": """",
                     ""groups"": """",
                     ""action"": ""Navigate"",
                     ""isComposite"": false,
-                    ""isPartOfComposite"": false
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""down"",
+                    ""id"": ""8db8a02c-9070-4af1-80ad-2268f539d331"",
+                    ""path"": ""<Gamepad>/leftStick/down"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Navigate"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""left"",
+                    ""id"": ""662e32c1-a736-413a-8664-708f266e7ac1"",
+                    ""path"": ""<Gamepad>/leftStick/left"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Navigate"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
+                },
+                {
+                    ""name"": ""right"",
+                    ""id"": ""942ac37e-e4eb-40df-9980-f59cae197209"",
+                    ""path"": ""<Gamepad>/leftStick/right"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Navigate"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": true
                 }
             ]
         }

--- a/Assets/Scripts/Input/PlayerInputActions.inputactions
+++ b/Assets/Scripts/Input/PlayerInputActions.inputactions
@@ -255,7 +255,7 @@
                     "id": "2d8bf38c-7242-4aab-b94b-f4bceee6bc92",
                     "expectedControlType": "Vector2",
                     "processors": "",
-                    "interactions": "",
+                    "interactions": "Press",
                     "initialStateCheck": false
                 },
                 {
@@ -488,15 +488,59 @@
                     "isPartOfComposite": true
                 },
                 {
-                    "name": "",
-                    "id": "e0c77a15-04ca-4550-bb1e-b22e60155046",
-                    "path": "<Gamepad>/leftStick",
+                    "name": "Left Stick [Gamepad]",
+                    "id": "83d380c9-a0bd-4a30-ab94-7b9706b9a7ba",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "10b54bb8-b3e0-4e8e-a0e2-84e8424c9beb",
+                    "path": "<Gamepad>/leftStick/up",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
                     "action": "Navigate",
                     "isComposite": false,
-                    "isPartOfComposite": false
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "8db8a02c-9070-4af1-80ad-2268f539d331",
+                    "path": "<Gamepad>/leftStick/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "662e32c1-a736-413a-8664-708f266e7ac1",
+                    "path": "<Gamepad>/leftStick/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "942ac37e-e4eb-40df-9980-f59cae197209",
+                    "path": "<Gamepad>/leftStick/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
                 }
             ]
         }


### PR DESCRIPTION
Added up\down\left\right composite with left stick directions. The "press" interaction needs to be added to the action (Navigate) and not to the binding (Left Stick [Gamepad]) at least in this case. Tried to add it only to the binding itself but that did not work for some reason. When DPAD and left stick was used interleaved the left stick just stopped working. Well, this configuration seems to work.